### PR TITLE
Remove "canonicalization" of OF rules matches for OF1.2

### DIFF
--- a/java_gen/pre-written/pom.xml
+++ b/java_gen/pre-written/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.projectfloodlight</groupId>
     <artifactId>openflowj</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0-kilda-1</version>
     <packaging>jar</packaging>
 
     <name>OpenFlowJ-Loxi</name>

--- a/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFOxmTest.java
+++ b/java_gen/pre-written/src/test/java/org/projectfloodlight/protocol/OFOxmTest.java
@@ -19,27 +19,53 @@ import org.projectfloodlight.openflow.types.IPv4Address;
 import org.projectfloodlight.openflow.types.IPv4AddressWithMask;
 
 public class OFOxmTest {
-    private OFOxms oxms;
+    private OFOxms oF13oxms;
+    private OFOxms oF12oxms;
 
     @Before
     public void setup() {
-        oxms = OFFactories.getFactory(OFVersion.OF_13).oxms();
+        oF12oxms = OFFactories.getFactory(OFVersion.OF_12).oxms();
+        oF13oxms = OFFactories.getFactory(OFVersion.OF_13).oxms();
     }
 
     @Test
-    public void testGetCanonicalFullMask() {
+    public void testOF12GetCanonicalFullMask() {
         IPv4AddressWithMask empty = IPv4AddressWithMask.of("0.0.0.0/0");
         assertEquals(IPv4Address.FULL_MASK, empty.getMask());
-        OFOxmIpv4SrcMasked ipv4SrcMasked = oxms.ipv4SrcMasked(empty.getValue(), empty.getMask());
+        OFOxmIpv4SrcMasked ipv4SrcMasked = oF12oxms.ipv4SrcMasked(empty.getValue(), empty.getMask());
+        // OF12 getCanonical() must not change anything
+        assertEquals(ipv4SrcMasked.getCanonical(), ipv4SrcMasked);
+    }
+
+    @Test
+    public void testOF13GetCanonicalFullMask() {
+        IPv4AddressWithMask empty = IPv4AddressWithMask.of("0.0.0.0/0");
+        assertEquals(IPv4Address.FULL_MASK, empty.getMask());
+        OFOxmIpv4SrcMasked ipv4SrcMasked = oF13oxms.ipv4SrcMasked(empty.getValue(), empty.getMask());
         // canonicalize should remove /0
         assertNull(ipv4SrcMasked.getCanonical());
     }
 
     @Test
-    public void testGetCanonicalNoMask() {
+    public void testOF12GetCanonicalNoMask() {
         IPv4AddressWithMask fullIp = IPv4AddressWithMask.of("1.2.3.4/32");
         assertEquals(IPv4Address.NO_MASK, fullIp.getMask());
-        OFOxmIpv4SrcMasked ipv4SrcMasked = oxms.ipv4SrcMasked(fullIp.getValue(), fullIp.getMask());
+        OFOxmIpv4SrcMasked ipv4SrcMasked = oF13oxms.ipv4SrcMasked(fullIp.getValue(), fullIp.getMask());
+        assertTrue(ipv4SrcMasked.isMasked());
+        assertEquals(IPv4Address.NO_MASK, ipv4SrcMasked.getMask());
+
+        // OF12 getCanonical() must not change anything
+        OFOxm<IPv4Address> canonical = ipv4SrcMasked.getCanonical();
+        assertThat(canonical, CoreMatchers.instanceOf(OFOxmIpv4SrcMasked.class));
+        assertTrue(canonical.isMasked());
+        assertEquals(IPv4Address.NO_MASK, canonical.getMask());
+    }
+
+    @Test
+    public void testOF13GetCanonicalNoMask() {
+        IPv4AddressWithMask fullIp = IPv4AddressWithMask.of("1.2.3.4/32");
+        assertEquals(IPv4Address.NO_MASK, fullIp.getMask());
+        OFOxmIpv4SrcMasked ipv4SrcMasked = oF13oxms.ipv4SrcMasked(fullIp.getValue(), fullIp.getMask());
         assertTrue(ipv4SrcMasked.isMasked());
         assertEquals(IPv4Address.NO_MASK, ipv4SrcMasked.getMask());
 
@@ -52,7 +78,7 @@ public class OFOxmTest {
     @Test
     public void testGetCanonicalNormalMask() {
         IPv4AddressWithMask ip = IPv4AddressWithMask.of("1.2.3.0/24");
-        OFOxmIpv4SrcMasked ipv4SrcMasked = oxms.ipv4SrcMasked(ip.getValue(), ip.getMask());
+        OFOxmIpv4SrcMasked ipv4SrcMasked = oF13oxms.ipv4SrcMasked(ip.getValue(), ip.getMask());
         assertTrue(ipv4SrcMasked.isMasked());
 
         // canonicalize should convert the masked oxm to the non-masked one

--- a/java_gen/templates/custom/OFOxm_getCanonical.java
+++ b/java_gen/templates/custom/OFOxm_getCanonical.java
@@ -3,6 +3,11 @@
         //:: if not msg.member_by_name("masked").value == "true":
         // exact match OXM is always canonical
         return this;
+        //:: elif version.ir_version.short_constant == 'OF_1_2':
+        // Skip canonicalisation due to issues with Accton based switches. This switches treat
+        // all "exact" match as masked match with zero mask. That lead to incorrect packets matching.
+        // As workaround masked match with ZERO_MASK is used.
+        return this;
         //:: else:
         //:: mask_type = msg.member_by_name("mask").java_type.public_type
         if (${mask_type}.NO_MASK.equals(mask)) {


### PR DESCRIPTION
Some Accton based switches treat exact match as masked match with
zero(FULL_MASK) mask. This lead to false positive matches.

As workaround for this issue masked match with ZERO_MASK is used... But
canonicalization process drops mask for such matches.

So to be able to use mentioned workaround, disabling
canonicalization(trivial masks (all-0, all-1) are converted to the main
representation) for OF1.2.